### PR TITLE
1.10 Build 71

### DIFF
--- a/RealismProjectSCR/Program.cs
+++ b/RealismProjectSCR/Program.cs
@@ -19,7 +19,7 @@ class Program
     public static long ProgramStartUnix;
 
     public static string ProjectDirectoryPath;
-    public static int BuildNumber = 70;
+    public static int BuildNumber = 71;
 
     static void Main()
     {

--- a/RealismProjectSCR/Shift.cs
+++ b/RealismProjectSCR/Shift.cs
@@ -206,8 +206,8 @@ namespace RealismProjectSCR
                     shift.Description
                 };
                 File.WriteAllLines(tempShiftPath + "Info.shift", infoContents);
-                File.WriteAllLines(tempShiftPath + "Legs.shift", new string[] { "" });
-                File.WriteAllLines(tempShiftPath + "Drivers.shift", new string[] { "" });
+                File.WriteAllLines(tempShiftPath + "Legs.shift", new string[0]);
+                File.WriteAllLines(tempShiftPath + "Drivers.shift", new string[0]);
                 return shift;
             }
         }


### PR DESCRIPTION
Fixed issue when trying to open a shift that was just created, by writing the files with an array with the lengh of 0, instead of 1.